### PR TITLE
Add a new mapping rule from the pinhole model to the laserscan message structure

### DIFF
--- a/src/serial_comm.cpp
+++ b/src/serial_comm.cpp
@@ -102,7 +102,7 @@ SerialComm::SerialComm(ros::NodeHandle nh, ros::NodeHandle nhp)
         poly[3] = -9.137795412258314e+06;
         poly[4] = 4.045684724836031e+06;
         poly[5] = -9.494901699902674e+05;
-        poly[6] = 9.219599710241470e+04;
+        poly[6] = 9.219599710241470e+04 + 5;
         stable_temperature=440.0; // 48degree
         temperature_sensi = 0.05623;
     }
@@ -128,7 +128,7 @@ SerialComm::SerialComm(ros::NodeHandle nh, ros::NodeHandle nhp)
         poly[3] = 3.266065347655729e+06;
         poly[4] = -1.487548484816432e+06;
         poly[5] = 3.563561476000117e+05 + 20;
-        poly[6] = -3.519452184644648e+04 - 9 + 6;
+        poly[6] = -3.519452184644648e+04 - 9 + 4;
         stable_temperature=460.0; // 48degree
         temperature_sensi = 0.05623;
     }


### PR DESCRIPTION
A slight different mapping way for the laserscan structure from the raw pixel structure:

```
 double th = atan2( (k - STEPSIZE/4) / (double)(STEPSIZE/2 - 16) * SENSOR_LENGTH, lensfocus);
 int index = (th - laserscan_msg.angle_min) / laserscan_msg.angle_increment;

 laserscan_msg.ranges[index] = dist_dataholder[k]/100;
 laserscan_msg.intensities[index] = reflectance_dataholder[k]/5000>1?1:reflectance_dataholder[k]/5000;
```

No big different, Just have a try